### PR TITLE
Remove short array syntax and make it compatible for 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.3
   - 5.4
 before_script:
   - cd tests

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ $filter->setRule(
     'state',
     'State not recognized.',
     function ($value) {
-        $states = [
+        $states = array(
             'AK', 'AL', 'AR', 'AZ',
             // ...
             'WA', 'WI', 'WV', 'WY',
-        ];
+        );
         return in_array($value, $states);
     }
 );
@@ -136,7 +136,7 @@ $filter->setRule(
     'phone_type',
     'Phone type not recognized.',
     function ($value) {
-        $types = ['cell', 'home', 'work'];
+        $types = array('cell', 'home', 'work');
         return in_array($value, $types);
     }
 );
@@ -345,22 +345,22 @@ fluent methods to set attributes and options on the field.
 // hint the view layer to treat the first_name field as a text input,
 // with size and maxlength attributes
 $form->setField('first_name', 'text')
-     ->setAttribs([
+     ->setAttribs(array(
         'size' => 20,
         'maxlength' => 20,
-     ]);
+     ));
 
 // hint the view layer to treat the state field as a select, with a 
 // particular set of options (the keys are the option values, and the values
 // are the displayed text)
 $form->setField('state', 'select')
-     ->setOptions([
+     ->setOptions(array(
         'AL' => 'Alabama',
         'AK' => 'Alaska',
         'AZ' => 'Arizona',
         'AR' => 'Arkansas',
         // ...
-     ]);
+     ));
 ```
 
 In our view layer, we can extract the hints for a field using the `get()`
@@ -372,19 +372,19 @@ method.
 $hints = $form->get('state');
 
 // the hints array looks like this:
-// $hints = [
+// $hints = array(
 //     'type' => 'select',      # the input type
 //     'name' => 'state',       # the input name
-//     'attribs' => [           # attributes as key-value pairs
+//     'attribs' => array(           # attributes as key-value pairs
 //         // ...
-//     ],
-//     'options' => [           # options as key-value pairs
+//     ),
+//     'options' => array(           # options as key-value pairs
 //         'AL' => 'Alabama',
 //         'AZ' => 'Arizona',
 //         // ...
-//     ],
+//     ),
 //     'value' => '',           # the current value of the input
-// ];
+// );
 ```
 
 The [Aura.View](http://github.com/auraphp/Aura.View) package comes with a

--- a/src/Aura/Input/Builder.php
+++ b/src/Aura/Input/Builder.php
@@ -55,7 +55,7 @@ class Builder implements BuilderInterface
      * create objects* (as vs class names).
      * 
      */
-    public function __construct(array $fieldset_map = [])
+    public function __construct(array $fieldset_map = array())
     {
         $this->fieldset_map = $fieldset_map;
     }

--- a/src/Aura/Input/Collection.php
+++ b/src/Aura/Input/Collection.php
@@ -49,8 +49,11 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * this collection.
      * 
      */
-    public function __construct(callable $factory)
+    public function __construct($factory)
     {
+        if (! is_callable($factory)) {
+            throw new \Exception("Should be callable");
+        }
         $this->factory = $factory;
     }
 

--- a/src/Aura/Input/Collection.php
+++ b/src/Aura/Input/Collection.php
@@ -39,7 +39,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @var array
      * 
      */
-    protected $fieldsets = [];
+    protected $fieldsets = array();
 
     /**
      * 
@@ -63,7 +63,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      */
     public function fill(array $data)
     {
-        $this->fieldsets = [];
+        $this->fieldsets = array();
         foreach ($data as $key => $inputs) {
             $fieldset = $this->newFieldset($key);
             foreach ($inputs as $name => $value) {
@@ -107,7 +107,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
             return $this->fieldsets[$key]->getMessages();
         }
         
-        $messages = [];
+        $messages = array();
         foreach ($this->fieldsets as $key => $fieldset) {
             $messages[$key] = $fieldset->getMessages();
         }

--- a/src/Aura/Input/Field.php
+++ b/src/Aura/Input/Field.php
@@ -36,7 +36,7 @@ class Field extends AbstractInput
      * @var array
      * 
      */
-    protected $attribs = [];
+    protected $attribs = array();
     
     /**
      * 
@@ -48,7 +48,7 @@ class Field extends AbstractInput
      * @var array
      * 
      */
-    protected $options = [];
+    protected $options = array();
     
     /**
      * 
@@ -109,22 +109,22 @@ class Field extends AbstractInput
     public function get()
     {
         $attribs = array_merge(
-            [
+            array(
                 // force a particular order on some attributes
                 'id'   => null,
                 'type' => null,
                 'name' => null,
-            ],
+            ),
             $this->attribs
         );
         
-        return [
+        return array(
             'type'          => $this->type,
             'name'          => $this->getFullName(),
             'attribs'       => $attribs,
             'options'       => $this->options,
             'value'         => $this->value,
-        ];
+        );
     }
     
     /**

--- a/src/Aura/Input/Fieldset.php
+++ b/src/Aura/Input/Fieldset.php
@@ -45,7 +45,7 @@ class Fieldset extends AbstractInput
      * @var array
      * 
      */
-    protected $inputs = [];
+    protected $inputs = array();
     
     /**
      * 

--- a/src/Aura/Input/Filter.php
+++ b/src/Aura/Input/Filter.php
@@ -26,7 +26,7 @@ class Filter implements FilterInterface
      * @var array
      * 
      */
-    protected $rules = [];
+    protected $rules = array();
     
     /**
      * 
@@ -35,7 +35,7 @@ class Filter implements FilterInterface
      * @var array
      * 
      */
-    protected $messages = [];
+    protected $messages = array();
     
     /**
      * 
@@ -52,7 +52,7 @@ class Filter implements FilterInterface
      */
     public function setRule($field, $message, \Closure $closure)
     {
-        $this->rules[$field] = [$message, $closure];
+        $this->rules[$field] = array($message, $closure);
     }
     
     /**
@@ -67,7 +67,7 @@ class Filter implements FilterInterface
     public function values(&$values)
     {
         // reset the messages
-        $this->messages = [];
+        $this->messages = array();
         
         // go through each of the rules
         foreach ($this->rules as $field => $rule) {
@@ -108,6 +108,6 @@ class Filter implements FilterInterface
             return $this->messages[$field];
         }
         
-        return [];
+        return array();
     }
 }

--- a/tests/Aura/Input/CollectionTest.php
+++ b/tests/Aura/Input/CollectionTest.php
@@ -17,12 +17,12 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = $this->newCollection();
         
-        $data = [
-            ['foo' => 'foo1'],
-            ['foo' => 'foo2'],
-            ['foo' => 'foo3'],
-            ['foo' => 'foo4'],
-        ];
+        $data = array(
+            array('foo' => 'foo1'),
+            array('foo' => 'foo2'),
+            array('foo' => 'foo3'),
+            array('foo' => 'foo4'),
+        );
         
         $collection->fill($data);
         
@@ -37,41 +37,41 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = $this->newCollection();
         
-        $data = [
-            ['foo' => 'foo'],
-            ['foo' => 'bar123'],
-            ['foo' => 'baz'],
-            ['foo' => 'dib123'],
-        ];
+        $data = array(
+            array('foo' => 'foo'),
+            array('foo' => 'bar123'),
+            array('foo' => 'baz'),
+            array('foo' => 'dib123'),
+        );
         
         $collection->fill($data);
         $actual = $collection->filter();
         $this->assertFalse($actual);
         
         $actual = $collection->getMessages();
-        $expect = [
-            0 => [],
-            1 => [
-                'foo' => [
+        $expect = array(
+            0 => array(),
+            1 => array(
+                'foo' => array(
                     'Use alpha only!',
-                ],
-            ],
-            2 => [],
-            3 => [
-                'foo' => [
+                ),
+            ),
+            2 => array(),
+            3 => array(
+                'foo' => array(
                     'Use alpha only!',
-                ],
-            ],
-        ];
+                ),
+            ),
+        );
         
         $this->assertSame($expect, $actual);
         
         $actual = $collection->getMessages(1);
-        $expect = [
-            'foo' => [
+        $expect = array(
+            'foo' => array(
                 'Use alpha only!',
-            ],
-        ];
+            ),
+        );
         $this->assertSame($expect, $actual);
     }
     
@@ -79,12 +79,12 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = $this->newCollection();
         
-        $data = [
-            ['foo' => 'foo'],
-            ['foo' => 'bar123'],
-            ['foo' => 'baz'],
-            ['foo' => 'dib123'],
-        ];
+        $data = array(
+            array('foo' => 'foo'),
+            array('foo' => 'bar123'),
+            array('foo' => 'baz'),
+            array('foo' => 'dib123'),
+        );
         
         $collection->fill($data);
         

--- a/tests/Aura/Input/Example/ExampleTest.php
+++ b/tests/Aura/Input/Example/ExampleTest.php
@@ -10,7 +10,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
     
     protected function setUp()
     {
-        $builder = new Builder([
+        $builder = new Builder(array(
             'address' => function () {
                 return new AddressFieldset(
                     new Builder,
@@ -23,7 +23,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
                     new Filter
                 );
             },
-        ]);
+        ));
         
         $this->form = new ContactForm($builder, new Filter);
     }
@@ -31,77 +31,77 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
     public function testAll()
     {
         // fill the form with data
-        $this->form->fill([
+        $this->form->fill(array(
             'first_name' => 'Bolivar',
             'last_name' => 'Shagnasty',
             'no_such_field' => 'nonesuch',
             'email' => 'boshag@example.com',
             'website' => 'http://boshag.example.com',
-            'address' => [
+            'address' => array(
                 'street' => '123 Main',
                 'city' => 'Beverly Hills',
                 'state' => 'CA',
                 'zip' => '90210',
-            ],
-            'phone_numbers' => [
-                0 => [
+            ),
+            'phone_numbers' => array(
+                0 => array(
                     'type' => 'mobile',
                     'number' => '123-456-7890',
-                ],
-                1 => [
+                ),
+                1 => array(
                     'type' => 'home',
                     'number' => '234-567-8901',
-                ],
-                2 => [
+                ),
+                2 => array(
                     'type' => 'fax',
                     'number' => '345-678-9012',
-                ],
-            ],
-        ]);
+                ),
+            ),
+        ));
         
         // first-level input
         $actual = $this->form->get('email');
-        $expect = [
+        $expect = array(
             'type' => 'text',
             'name' => 'email',
-            'attribs' => [
+            'attribs' => array(
                 'id' => NULL,
                 'type' => NULL,
                 'name' => NULL,
-            ],
-            'options' => [],
+            ),
+            'options' => array(),
             'value' => 'boshag@example.com',
-        ];
+        );
         $this->assertSame($expect, $actual);
         
         // fieldset-level input
         $actual = $this->form->address->get('street');
-        $expect = [
+        $expect = array(
             'type' => 'text',
             'name' => 'address[street]',
-            'attribs' => [
+            'attribs' => array(
                 'id' => NULL,
                 'type' => NULL,
                 'name' => NULL,
-            ],
-            'options' => [],
+            ),
+            'options' => array(),
             'value' => '123 Main',
-        ];
+        );
         $this->assertSame($expect, $actual);
         
         // collection-level input
         $actual = $this->form->phone_numbers[1]->get('number');
-        $expect = [
+        $expect = array(
             'type' => 'text',
             'name' => 'phone_numbers[1][number]',
-            'attribs' => [
+            'attribs' => array(
                 'id' => NULL,
                 'type' => NULL,
                 'name' => NULL,
-            ],
-            'options' => [],
+            ),
+            'options' => array(),
             'value' => '234-567-8901',
-        ];
+        );
         $this->assertSame($expect, $actual);
         
         

--- a/tests/Aura/Input/FieldTest.php
+++ b/tests/Aura/Input/FieldTest.php
@@ -8,24 +8,24 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $field = new Field('text');
         $field->setName('field_name')
               ->setNamePrefix('prefix')
-              ->setAttribs(['foo' => 'bar'])
-              ->setOptions(['baz' => 'dib'])
+              ->setAttribs(array('foo' => 'bar'))
+              ->setOptions(array('baz' => 'dib'))
               ->setValue('doom');
         
         $actual = $field->get();
         
-        $expect = [
+        $expect = array(
             'type' => 'text',
             'name' => 'prefix[field_name]',
-            'attribs' => [
+            'attribs' => array(
                 'id'   => null,
                 'type' => null,
                 'name' => null,
                 'foo'  => 'bar',
-            ],
-            'options' => ['baz' => 'dib'],
+            ),
+            'options' => array('baz' => 'dib'),
             'value' => 'doom',
-        ];
+        );
         
         $this->assertSame($expect, $actual);
         

--- a/tests/Aura/Input/FieldsetTest.php
+++ b/tests/Aura/Input/FieldsetTest.php
@@ -61,32 +61,32 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         $fieldset = $this->newFieldset();
         
         $fieldset->setField('field1', 'text')
-                 ->setAttribs(['foo' => 'bar'])
-                 ->setOptions(['baz' => 'dib']);
+                 ->setAttribs(array('foo' => 'bar'))
+                 ->setOptions(array('baz' => 'dib'));
         
         $fieldset->setField('field2', 'date')
-                 ->setAttribs(['zim' => 'gir'])
-                 ->setOptions(['irk' => 'doom']);
+                 ->setAttribs(array('zim' => 'gir'))
+                 ->setOptions(array('irk' => 'doom'));
         
         $actual = $fieldset->get('field2');
-        $expect = [
+        $expect = array(
             'type' => 'date',
             'name' => 'field2',
-            'attribs' => [
+            'attribs' => array(
                 'id' => null,
                 'type' => null,
                 'name' => null,
                 'zim' => 'gir',
-            ],
-            'options' => ['irk' => 'doom'],
+            ),
+            'options' => array('irk' => 'doom'),
             'value' => null,
-        ];
+        );
         
         $this->assertSame($expect, $actual);
         
         // get the names
         $actual = $fieldset->getInputNames();
-        $expect = ['field1', 'field2'];
+        $expect = array('field1', 'field2');
         $this->assertSame($expect, $actual);
     }
     
@@ -106,18 +106,18 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         });
         
         // set values on the fieldset
-        $fieldset->fill(['foo' => 'foo_value', 'bar' => 'bar_value']);
+        $fieldset->fill(array('foo' => 'foo_value', 'bar' => 'bar_value'));
         
         // apply the filter
         $passed = $fieldset->filter();
         $this->assertFalse($passed);
         
         $actual = $fieldset->getMessages();
-        $expect = [
-            'foo' => [
+        $expect = array(
+            'foo' => array(
                 'Foo should be alpha',
-            ],
-        ];
+            ),
+        );
         $this->assertSame($expect, $actual);
     }
     

--- a/tests/Aura/Input/FilterTest.php
+++ b/tests/Aura/Input/FilterTest.php
@@ -41,12 +41,12 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testAll()
     {
         // initial data
-        $values = (object) [
+        $values = (object) array(
             'foo' => 'foo_value',
             'bar' => 'bar_value',
             'baz' => 'baz_value',
             'baz_confirm' => 'baz_value',
-        ];
+        );
         
         // do the values pass all filters?
         $passed = $this->filter->values($values);
@@ -56,30 +56,30 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         
         // get all messages
         $actual = $this->filter->getMessages();
-        $expect = [
-            'foo' => [
+        $expect = array(
+            'foo' => array(
                 'Foo should be alpha only',
-            ]
-        ];
+            )
+        );
         $this->assertSame($expect, $actual);
         
         // get just 'foo' messages
         $actual = $this->filter->getMessages('foo');
-        $expect = [
+        $expect = array(
             'Foo should be alpha only',
-        ];
+        );
         $this->assertSame($expect, $actual);
         
         // no failures on nonexistent field
-        $this->assertSame([], $this->filter->getMessages('no-such-failure'));
+        $this->assertSame(array(), $this->filter->getMessages('no-such-failure'));
         
         // should have changed the values on 'bar'
-        $expect = (object) [
+        $expect = (object) array(
             'foo' => 'foo_value',
             'bar' => 'bar!value',
             'baz' => 'baz_value',
             'baz_confirm' => 'baz_value',
-        ];
+        );
         $this->assertEquals($expect, $values);
         
         // let's make it valid

--- a/tests/Aura/Input/FormTest.php
+++ b/tests/Aura/Input/FormTest.php
@@ -10,7 +10,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $form->setField('foo');
         
         // there should be only one field
-        $expect = ['foo'];
+        $expect = array('foo');
         $actual = $form->getInputNames();
         $this->assertSame($expect, $actual);
         
@@ -20,7 +20,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($csrf, $form->getAntiCsrf());
         
         // there should be two fields now
-        $expect = ['foo', '__csrf_token'];
+        $expect = array('foo', '__csrf_token');
         $actual = $form->getInputNames();
         $this->assertSame($expect, $actual);
     }
@@ -36,7 +36,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $form->setAntiCsrf($csrf);
         
         // load it with a missing csrf token
-        $data = ['foo' => 'bar'];
+        $data = array('foo' => 'bar');
         $this->setExpectedException('Aura\Input\Exception\CsrfViolation');
         $form->fill($data);
     }
@@ -52,7 +52,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $form->setAntiCsrf($csrf);
         
         // load it with a bad token    
-        $data = ['foo' => 'bar', '__csrf_token' => 'badvalue'];
+        $data = array('foo' => 'bar', '__csrf_token' => 'badvalue');
         $this->setExpectedException('Aura\Input\Exception\CsrfViolation');
         $form->fill($data);
     }
@@ -68,7 +68,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $form->setAntiCsrf($csrf);
         
         // load it with a good token
-        $data = ['foo' => 'bar', '__csrf_token' => 'goodvalue'];
+        $data = array('foo' => 'bar', '__csrf_token' => 'goodvalue');
         $form->fill($data);
         $this->assertSame('bar', $form->foo);
     }
@@ -82,6 +82,6 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         $iterator = $form->getIterator();
         $keys = array_keys($iterator->getArrayCopy());
-        $this->assertSame(['foo', 'bar'], $keys);
+        $this->assertSame(array('foo', 'bar'), $keys);
     }
 }


### PR DESCRIPTION
Have removed the type callable from 

``` php
-    public function __construct(callable $factory)
+    public function __construct($factory)
     {
+        if (! is_callable($factory)) {
+            throw new \Exception("Should be callable");
+        }
         $this->factory = $factory;
     } 
```

https://github.com/harikt/Aura.Input/commit/8f374c1acb243932b089fafef811ddee710fd572

The exception can be moved to its own place.

https://travis-ci.org/harikt/Aura.Input/jobs/8448918

Let me know your comments
