### PR TITLE
Add support for adding messages in closure rules

### DIFF
--- a/src/Aura/Input/Filter.php
+++ b/src/Aura/Input/Filter.php
@@ -81,7 +81,12 @@ class Filter implements FilterInterface
             // note that it is in an array, so that other implementations
             // can allow for multiple messages.
             if (! $passed) {
-                $this->messages[$field][] = $message;
+                if (! isset($this->messages[$field])) {
+                    $this->messages[$field][] = $message;
+                } else {
+                    // the message should be first.
+                    array_unshift($this->messages[$field], $message);
+                }
             }
         }
         
@@ -125,9 +130,13 @@ class Filter implements FilterInterface
      */
     public function addMessages($field, $messages)
     {
-        $this->messages[$field] = array_merge(
-            $this->messages[$field],
-            (array) $messages
-        );
+        if (! isset($this->messages[$field])) {
+            $this->messages[$field][] = $messages;
+        } else {
+            $this->messages[$field] = array_merge(
+                $this->messages[$field],
+                (array) $messages
+            );
+        }
     }
 }

--- a/tests/Aura/Input/FilterTest.php
+++ b/tests/Aura/Input/FilterTest.php
@@ -99,4 +99,45 @@ class FilterTest extends \PHPUnit_Framework_TestCase
         $passed = $this->filter->values($values);
         $this->assertTrue($passed);
     }
+    
+     public function testMultipleErrorMessages()
+    {
+        // initial data
+        $values = (object) [
+            'foo' => '',
+        ];
+        
+        // set the rule of 'foo'
+        $filter = new Filter;
+        $filter->setRule(
+            'foo',
+            'Enter Foo correctly',
+            function ($value) use ($filter) {
+                $pass = true;
+                if ($value == '') {
+                    $filter->addMessages('foo', 'Foo is required');
+                    $pass = false;
+                }
+                
+                if (! ctype_alpha($value)) {
+                    $filter->addMessages('foo', 'Foo should be alpha only');
+                    $pass = false;
+                }
+                return $pass;
+            }
+        );
+        
+        // do the values pass the filter?
+        $passed = $filter->values($values);
+        $this->assertFalse($passed);
+        
+        // get 'foo' messages
+        $actual = $filter->getMessages('foo');
+        $expect = [
+            'Enter Foo correctly',
+            'Foo is required',
+            'Foo should be alpha only',
+        ];
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
This PR makes it possible to add messages in a closure.

``` php
        $filter->setRule(
            'foo',
            'Enter Foo correctly',
            function ($value) use ($filter) {
                $pass = true;
                if ($value == '') {
                    $filter->addMessages('foo', 'Foo is required');
                    $pass = false;
                }

                if (! ctype_alpha($value)) {
                    $filter->addMessages('foo', 'Foo should be alpha only');
                    $pass = false;
                }
                return $pass;
            }
        );
```
