### PR TITLE
isSuccess

### DIFF
--- a/src/Aura/Input/Fieldset.php
+++ b/src/Aura/Input/Fieldset.php
@@ -243,6 +243,17 @@ class Fieldset extends AbstractInput
     
     /**
      * 
+     * Did the input data pass the filter rules?
+     * 
+     * @return null|bool
+     * 
+     */
+    public function isSuccess()
+    {
+    }
+    
+    /**
+     * 
      * Sets a new Field input.
      * 
      * @param string $name The Field name.

--- a/src/Aura/Input/Fieldset.php
+++ b/src/Aura/Input/Fieldset.php
@@ -59,6 +59,15 @@ class Fieldset extends AbstractInput
     
     /**
      * 
+     * Property for storing the result of the last filter() call.
+     * 
+     * @var bool
+     * 
+     */
+    protected $success;
+    
+    /**
+     * 
      * Constructor.
      * 
      * @param BuilderInterface $builder An object to build input objects.
@@ -250,6 +259,7 @@ class Fieldset extends AbstractInput
      */
     public function isSuccess()
     {
+        return $this->success;
     }
     
     /**
@@ -337,7 +347,7 @@ class Fieldset extends AbstractInput
      */
     public function filter()
     {
-        return $this->filter->values($this);
+        return $this->success = $this->filter->values($this);
     }
     
     /**

--- a/tests/Aura/Input/FieldsetTest.php
+++ b/tests/Aura/Input/FieldsetTest.php
@@ -121,6 +121,42 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
     
+    public function testIsSuccessAll()
+    {
+        // new fieldset
+        $fieldset = $this->newFieldset();
+        
+        // add fields
+        $fieldset->setField('foo');
+        $fieldset->setField('bar');
+        
+        // get the filter and add a rule
+        $filter = $fieldset->getFilter();
+        $filter->setRule('foo', 'Foo should be alpha', function ($value) {
+            return ctype_alpha($value);
+        });
+        
+        // set values on the fieldset
+        $fieldset->fill(['foo' => 'foo_value', 'bar' => 'bar_value']);
+        
+        // Filter has not been called, so isSuccess must return null
+        $this->assertNull($fieldset->isSuccess());
+        
+        // apply the filter
+        $pass = $fieldset->filter();
+        
+        // After calling filter, isSuccess should return a boolean
+        // and filter() should also return a boolean
+        $this->assertFalse($fieldset->isSuccess());
+        $this->assertFalse($pass);
+        
+        // Let's fix the data and test if isSuccess returns true
+        $fieldset->fill(['foo' => 'fooValue', 'bar' => 'barValue']);
+        $pass = $fieldset->filter();
+        $this->assertTrue($fieldset->isSuccess());
+        $this->assertTrue($pass);
+    }
+    
     public function testSetFieldset()
     {
         // a map so the outer fieldset can create the inner fieldset


### PR DESCRIPTION
Hi

In relation to feature request #38 I'm creating this pull request for the addition of the `isSuccess()` method on a `Fieldset`.

I haven't implemented the method yet, so the unit tests fail. I will try and work on the method sometime in the next several days.

I do have a question though: if the `filter` object or input data is modified in any way, should `isSuccess()` revert back to returning `null`? For example:

```
$form->fill($data)->filter();
$form->isSuccess(); // returns true or false
$form->fill($newData);
$form->isSuccess(); // returns null
```

Cheers
Stephen
