### PR TITLE
WIP : Move to php 7 and strict types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: php
-php:  
-  - hhvm
+php:    
   - 7
+  - 7.1
 before_script:
   - composer self-update
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: php
 php:  
-  - 5.6
   - hhvm
   - 7
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 php:    
   - 7

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,9 @@
             "homepage": "https://github.com/auraphp/Aura.Input/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/harikt/Aura.Filter_Interface"
-        }
-    ],
     "require": {
-        "php": ">=5.6.0",
-        "aura/filter-interface":"@dev"
+        "php": ">=7.0.0",
+        "aura/filter-interface":"3.x@dev"
     },
     "autoload": {
         "psr-4": {
@@ -35,5 +29,8 @@
         "psr-4": {
             "Aura\\Input\\": "tests/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.0"
     }
 }

--- a/src/AbstractInput.php
+++ b/src/AbstractInput.php
@@ -1,80 +1,81 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 /**
- * 
+ *
  * An abstract input class; serves as the base for Fields, Fieldsets, and
  * Collections.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 abstract class AbstractInput
 {
     /**
-     * 
+     *
      * The name for the input.
-     * 
+     *
      * @var string
-     * 
+     *
      */
     protected $name;
-    
+
     /**
-     * 
+     *
      * The prefix for the name, typically composed of the parent input names.
-     * 
+     *
      * @var string
-     * 
+     *
      */
     protected $name_prefix;
-    
+
     /**
-     * 
+     *
      * Sets the name for the input.
-     * 
+     *
      * @param string $name The input name.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function setName($name)
     {
         $this->name = $name;
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Sets the name prefix for the input, typically composed of the parent
      * input names.
-     * 
+     *
      * @param string $name_prefix The name prefix.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function setNamePrefix($name_prefix)
     {
         $this->name_prefix = $name_prefix;
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Returns the full name for this input, incuding the prefix (if any).
-     * 
+     *
      * @return string
-     * 
+     *
      */
     public function getFullName()
     {
@@ -84,37 +85,37 @@ abstract class AbstractInput
         }
         return $name;
     }
-    
+
     /**
-     * 
+     *
      * Support for this input when addressed via Fieldset::__get().
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function read()
     {
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Returns this input for the presentation layer.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function get()
     {
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Returns the value of this input for use in arrays.
-     * 
+     *
      * @return mixed
-     * 
+     *
      */
     abstract public function getValue();
 }

--- a/src/AntiCsrfInterface.php
+++ b/src/AntiCsrfInterface.php
@@ -1,46 +1,47 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 /**
- * 
+ *
  * Defines the interface for anti-CSRF protection logic.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 interface AntiCsrfInterface
 {
     /**
-     * 
+     *
      * Sets the field value for the anti-CSRF value.
-     * 
+     *
      * @param Fieldset $fieldset The fieldset on which to set the anti-CSRF
      * value.
-     * 
+     *
      * @return void
-     * 
+     *
      */
     public function setField(Fieldset $fieldset);
-    
+
     /**
-     * 
+     *
      * Checks the raw user input to see if the incoming anti-CSRF value is
      * valid.
-     * 
+     *
      * @param array $data The incoming user data, generally from $_POST.
-     * 
+     *
      * @return bool True if the incoming data has the correct anti-CSRF value,
      * false if not.
-     * 
+     *
      */
     public function isValid(array $data);
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,75 +1,76 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 /**
- * 
+ *
  * A builder to create Field, Fieldset, and fieldset Collection objects.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 class Builder implements BuilderInterface
 {
     /**
-     * 
+     *
      * The class to use for creating fieldset collections.
-     * 
+     *
      * @var string
-     * 
+     *
      */
     protected $collection_class = 'Aura\Input\Collection';
-    
+
     /**
-     * 
+     *
      * The class to use for creating fields.
-     * 
+     *
      * @var string
-     * 
+     *
      */
     protected $field_class = 'Aura\Input\Field';
-    
+
     /**
-     * 
+     *
      * A map of fieldset types to *callables that create objects* (as
      * vs class names).
-     * 
+     *
      * @var array
-     * 
+     *
      */
     protected $fieldset_map;
-    
+
     /**
-     * 
+     *
      * Constructor.
-     * 
+     *
      * @param array $fieldset_map A map of fieldset types to *callables that
      * create objects* (as vs class names).
-     * 
+     *
      */
     public function __construct(array $fieldset_map = [])
     {
         $this->fieldset_map = $fieldset_map;
     }
-    
+
     /**
-     * 
+     *
      * Creates a new Field object.
-     * 
+     *
      * @param string $name The field name.
-     * 
+     *
      * @param string $type The field type.
-     * 
+     *
      * @return Field
-     * 
+     *
      */
     public function newField($name, $type = null)
     {
@@ -81,17 +82,17 @@ class Builder implements BuilderInterface
         $field->setName($name);
         return $field;
     }
-    
+
     /**
-     * 
+     *
      * Creates a new Fieldset object.
-     * 
+     *
      * @param string $name The fieldset name.
-     * 
+     *
      * @param string $type The fieldset type.
-     * 
+     *
      * @return Fieldset
-     * 
+     *
      */
     public function newFieldset($name, $type = null)
     {
@@ -103,17 +104,17 @@ class Builder implements BuilderInterface
         $fieldset->setName($name);
         return $fieldset;
     }
-    
+
     /**
-     * 
+     *
      * Creates a new Collection object.
-     * 
+     *
      * @param string $name The collection name.
-     * 
+     *
      * @param string $type The collection type.
-     * 
+     *
      * @return Collection
-     * 
+     *
      */
     public function newCollection($name, $type = null)
     {

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -1,60 +1,61 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 /**
- * 
+ *
  * The interface for a builder to create fields, fieldsets, and fieldset
  * collections.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 interface BuilderInterface
 {
     /**
-     * 
+     *
      * Creates a new Field object.
-     * 
+     *
      * @param string $name The field name.
-     * 
+     *
      * @param string $type The field type.
-     * 
+     *
      * @return Field
-     * 
+     *
      */
     public function newField($name, $type);
-    
+
     /**
-     * 
+     *
      * Creates a new Fieldset object.
      *
      * @param string $name The fieldset name.
-     *  
+     *
      * @param string $type The fieldset type.
      *
      * @return Fieldset
-     * 
+     *
      */
     public function newFieldset($name, $type);
     /**
-     * 
+     *
      * Creates a new Collection object.
-     * 
+     *
      * @param string $name The collection name.
-     * 
+     *
      * @param string $type The collection type.
-     * 
+     *
      * @return Collection
-     * 
+     *
      */
     public function newCollection($name, $type);
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.
@@ -126,7 +127,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return array
      *
      */
-    public function getKeys()
+    public function getKeys() : array
     {
         return array_keys($this->fieldsets);
     }
@@ -140,7 +141,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return Fieldset
      *
      */
-    protected function newFieldset($key)
+    protected function newFieldset($key) : Fieldset
     {
         $factory = $this->factory;
         $fieldset = $factory();
@@ -157,7 +158,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return Fieldset
      *
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset) : Fieldset
     {
         $fieldset = $this->fieldsets[$offset];
         $fieldset->setNamePrefix($this->getFullName());
@@ -189,7 +190,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return bool True if the Fielset key is set, false if not.
      *
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return isset($this->fieldsets[$offset]);
     }
@@ -215,7 +216,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return int
      *
      */
-    public function count()
+    public function count() : int
     {
         return count($this->fieldsets);
     }
@@ -227,7 +228,7 @@ class Collection extends AbstractInput implements ArrayAccess, Countable, Iterat
      * @return array
      *
      */
-    public function getValue()
+    public function getValue() : array
     {
         $data = [];
         foreach ($this->fieldsets as $key => $fieldset) {

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.
@@ -23,12 +24,12 @@ class CollectionIterator implements Iterator
 {
     /**
      *
-     * The fieldsets over which we are iterating.
+     * Represents a collection of fieldsets.
      *
-     * @var array
+     * @var Collection
      *
      */
-    protected $fieldsets;
+    protected $collection;
 
     /**
      *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.

--- a/src/Exception/CsrfViolation.php
+++ b/src/Exception/CsrfViolation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.

--- a/src/Exception/NoSuchForm.php
+++ b/src/Exception/NoSuchForm.php
@@ -1,23 +1,24 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input\Exception;
 
 use Aura\Input\Exception;
 
 /**
- * 
+ *
  * The requested form does not exist.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 class NoSuchForm extends Exception
 {

--- a/src/Exception/NoSuchInput.php
+++ b/src/Exception/NoSuchInput.php
@@ -1,23 +1,24 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input\Exception;
 
 use Aura\Input\Exception;
 
 /**
- * 
+ *
  * The requested input does not exist.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 class NoSuchInput extends Exception
 {

--- a/src/Field.php
+++ b/src/Field.php
@@ -1,110 +1,111 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 /**
- * 
+ *
  * A single field in a fieldset.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 class Field extends AbstractInput
 {
     /**
-     * 
+     *
      * The field type.
-     * 
+     *
      * @var string
-     * 
+     *
      */
     protected $type;
-    
+
     /**
-     * 
+     *
      * HTML attributes for the field as key-value pairs. The key is the
      * attribute name and the value is the attribute value.
-     * 
+     *
      * @var array
-     * 
+     *
      */
     protected $attribs = [];
-    
+
     /**
-     * 
+     *
      * Options for the field as key-value pairs (typically for select and
      * radio elements). The key is the option value and the value is the
      * option label.  Nested options may be honored as the key being an
      * optgroup label and the array value as the options under that optgroup.
-     * 
+     *
      * @var array
-     * 
+     *
      */
     protected $options = [];
-    
+
     /**
-     * 
+     *
      * The value for the field.  This may or may not be the same as the
      * 'value' attribue.
-     * 
+     *
      * @var mixed
-     * 
+     *
      */
     protected $value;
-    
+
     /**
-     * 
+     *
      * Constructor.
-     * 
+     *
      * @param string $type The field type.
-     * 
+     *
      */
     public function __construct($type)
     {
         $this->type = $type;
     }
-    
+
     /**
-     * 
+     *
      * Fills this field with a value.
-     * 
+     *
      * @param mixed $value The value for the field.
-     * 
+     *
      * @return void
-     * 
+     *
      */
     public function fill($value)
     {
         $this->value = $value;
     }
-    
+
     /**
-     * 
+     *
      * Reads the value from this field.
-     * 
+     *
      * @return mixed
-     * 
+     *
      */
     public function read()
     {
         return $this->value;
     }
-    
+
     /**
-     * 
+     *
      * Returns this field as a plain old PHP array for use in a view.
-     * 
-     * @return array An array with keys `'type'`, `'name'`, `'attribs'`, 
+     *
+     * @return array An array with keys `'type'`, `'name'`, `'attribs'`,
      * `'options'`, and `'value'`.
-     * 
+     *
      */
     public function get()
     {
@@ -117,7 +118,7 @@ class Field extends AbstractInput
             ],
             $this->attribs
         );
-        
+
         return [
             'type'          => $this->type,
             'name'          => $this->getFullName(),
@@ -126,62 +127,62 @@ class Field extends AbstractInput
             'value'         => $this->value,
         ];
     }
-    
+
     /**
-     * 
+     *
      * Sets the HTML attributes on this field.
-     * 
+     *
      * @param array $attribs HTML attributes for the field as key-value pairs;
      * the key is the attribute name and the value is the attribute value.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function setAttribs(array $attribs)
     {
         $this->attribs = $attribs;
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Sets the value options for this field, typically for select and radios.
-     * 
+     *
      * @param array $options Options for the field as key-value pairs. The key
      * is the option value and the value is the option label.  Nested options
      * may be honored as the key being an optgroup label and the array value
      * as the options under that optgroup.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function setOptions(array $options)
     {
         $this->options = $options;
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Sets the value on this field.
-     * 
+     *
      * @param mixed $value The value for the field.
-     * 
+     *
      * @return self
-     * 
+     *
      */
     public function setValue($value)
     {
         $this->value = $value;
         return $this;
     }
-    
+
     /**
-     * 
+     *
      * Returns the value of this input for use in arrays.
-     * 
+     *
      * @return mixed
-     * 
+     *
      */
     public function getValue()
     {

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.
@@ -245,7 +246,7 @@ class Fieldset extends AbstractInput
      */
     public function fill(array $data)
     {
-        $this->success = null;
+        $this->success = NULL;
         foreach ($this->inputs as $key => $input) {
             if (array_key_exists($key, $data)) {
                 $input->fill($data[$key]);

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.

--- a/src/Filter/FailureCollection.php
+++ b/src/Filter/FailureCollection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of Aura for PHP.
@@ -64,7 +65,7 @@ class FailureCollection  implements FailureCollectionInterface
      *
      */
     public function getMessages()
-    {        
+    {
         return $this->messages;
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  *
  * This file is part of the Aura project for PHP.

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -1,41 +1,42 @@
 <?php
+declare(strict_types=1);
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  * @license http://opensource.org/licenses/MIT-license.php MIT
- * 
+ *
  */
 namespace Aura\Input;
 
 use Aura\Input\Exception;
 
 /**
- * 
+ *
  * A factory to create top-level form objects by name.
- * 
+ *
  * @package Aura.Input
- * 
+ *
  */
 class FormFactory
 {
     /**
-     * 
+     *
      * A map of form names to factory callables.
-     * 
+     *
      * @var array
-     * 
+     *
      */
     protected $map = [];
 
     /**
-     * 
+     *
      * Constructor.
-     * 
+     *
      * @param array $map A map of form names to factory callables.
-     * 
+     *
      */
     public function __construct($map = [])
     {
@@ -43,22 +44,22 @@ class FormFactory
     }
 
     /**
-     * 
+     *
      * Returns a new instance of a named form.
-     * 
+     *
      * @param string $name The name of the form to create.
-     * 
+     *
      * @return Form
-     * 
+     *
      * @throws Exception\NoSuchForm When the named form does not exist.
-     * 
+     *
      */
     public function newInstance($name)
     {
         if (! isset($this->map[$name])) {
             throw new Exception\NoSuchForm($name);
         }
-        
+
         $factory = $this->map[$name];
         $form = $factory();
         return $form;

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -3,7 +3,7 @@ namespace Aura\Input;
 
 use ArrayObject;
 
-class CollectionTest extends \PHPUnit_Framework_TestCase
+class CollectionTest extends \PHPUnit\Framework\TestCase
 {
     public function newCollection()
     {

--- a/tests/Example/AddressFilter.php
+++ b/tests/Example/AddressFilter.php
@@ -1,0 +1,26 @@
+<?php
+namespace Aura\Input\Example;
+
+use Aura\Input\Filter;
+
+class AddressFilter extends Filter
+{
+    protected function init()
+    {
+        $this->addRule(
+            'street',
+            'Street name must be present.',
+            function ($value) {
+                return ! empty($value);
+            }
+        );
+
+        $this->addRule(
+            'city',
+            'City name must be present.',
+            function ($value) {
+                return ! empty($value);
+            }
+        );
+    }
+}

--- a/tests/Example/ExampleTest.php
+++ b/tests/Example/ExampleTest.php
@@ -4,7 +4,7 @@ namespace Aura\Input\Example;
 use Aura\Input\Builder;
 use Aura\Input\Filter;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
     protected $form;
 
@@ -14,13 +14,13 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
             'address' => function () {
                 return new AddressFieldset(
                     new Builder,
-                    new Filter
+                    new AddressFilter
                 );
             },
             'phone' => function () {
                 return new PhoneFieldset(
                     new Builder,
-                    new Filter
+                    new PhoneFilter
                 );
             },
         ]);
@@ -103,5 +103,41 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
             'value' => '234-567-8901',
         ];
         $this->assertSame($expect, $actual);
+    }
+
+
+    public function testAllFiltersAreCalled()
+    {
+        // fill the form with data
+        $this->form->fill([
+            'first_name' => 'Bolivar',
+            'last_name' => 'Shagnasty',
+            'no_such_field' => 'nonesuch',
+            'email' => 'boshag@example.com',
+            'website' => 'http://boshag.example.com',
+            'address' => [
+                'street' => '123 Main',
+                'city' => 'Beverly Hills',
+                'state' => 'CA',
+                'zip' => '90210',
+            ],
+            'phone_numbers' => [
+                0 => [
+                    'type' => 'somethingelse',
+                    'number' => '123-456-7890',
+                ],
+                1 => [
+                    'type' => 'home',
+                    'number' => '234-567-8901',
+                ],
+                2 => [
+                    'type' => 'fax',
+                    'number' => '345-678-9012',
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($this->form->filter());
+        // $this->form->getFailures();
     }
 }

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Aura\Input;
 
-class FieldTest extends \PHPUnit_Framework_TestCase
+class FieldTest extends \PHPUnit\Framework\TestCase
 {
     public function testAll()
     {

--- a/tests/FieldsetTest.php
+++ b/tests/FieldsetTest.php
@@ -3,7 +3,7 @@ namespace Aura\Input;
 
 use ArrayObject;
 
-class FieldsetTest extends \PHPUnit_Framework_TestCase
+class FieldsetTest extends \PHPUnit\Framework\TestCase
 {
     public function newFieldset()
     {
@@ -30,17 +30,21 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo_value', $fieldset->foo);
     }
 
+    /**
+     * @expectedException Aura\Input\Exception\NoSuchInput
+     */
     public function test__set_noSuchInput()
     {
         $fieldset = $this->newFieldset();
-        $this->setExpectedException('Aura\Input\Exception\NoSuchInput');
         $fieldset->foo = 'no such input';
     }
 
+    /**
+     * @expectedException Aura\Input\Exception\NoSuchInput
+     */
     public function test__get_noSuchInput()
     {
         $fieldset = $this->newFieldset();
-        $this->setExpectedException('Aura\Input\Exception\NoSuchInput');
         $foo = $fieldset->foo;
     }
 
@@ -51,10 +55,12 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($fieldset, $actual);
     }
 
+    /**
+     * @expectedException Aura\Input\Exception\NoSuchInput
+     */
     public function testGet_noSuchInput()
     {
         $fieldset = $this->newFieldset();
-        $this->setExpectedException('Aura\Input\Exception\NoSuchInput');
         $fieldset->get('foo');
     }
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -3,7 +3,7 @@ namespace Aura\Input;
 
 use ArrayObject;
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends \PHPUnit\Framework\TestCase
 {
     protected $filter;
 

--- a/tests/FormFactoryTest.php
+++ b/tests/FormFactoryTest.php
@@ -3,21 +3,31 @@ namespace Aura\Input;
 
 use StdClass;
 
-class FormFactoryTest extends \PHPUnit_Framework_TestCase
+class FormFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    public function test()
+
+    public function setUp()
     {
         $map = [
             'mock' => function () {
                 return new StdClass;
             },
         ];
-        $form_factory = new FormFactory($map);
-        
-        $actual = $form_factory->newInstance('mock');
+        $this->form_factory = new FormFactory($map);
+    }
+
+    public function test_newInstanceCanGetObject()
+    {
+
+        $actual = $this->form_factory->newInstance('mock');
         $this->assertInstanceOf('StdClass', $actual);
-        
-        $this->setExpectedException('Aura\Input\Exception\NoSuchForm');
-        $form_factory->newInstance('badname');
+    }
+
+    /**
+     * @expectedException Aura\Input\Exception\NoSuchForm
+     */
+    public function test_newInstanceNoSuchForm()
+    {
+        $this->form_factory->newInstance('badname');
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -7,7 +7,7 @@ use Aura\Input\Example\ContactForm;
 use Aura\Input\Example\PhoneFieldset;
 use Aura\Input\Example\PhoneFilter;
 
-class FormTest extends \PHPUnit_Framework_TestCase
+class FormTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddCsrf()
     {
@@ -31,6 +31,9 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $actual);
     }
 
+    /**
+     * @expectedException Aura\Input\Exception\CsrfViolation
+     */
     public function testMissingCsrf()
     {
         // set up the basic form
@@ -43,10 +46,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         // load it with a missing csrf token
         $data = ['foo' => 'bar'];
-        $this->setExpectedException('Aura\Input\Exception\CsrfViolation');
         $form->fill($data);
     }
 
+    /**
+     * @expectedException Aura\Input\Exception\CsrfViolation
+     */
     public function testBadCsrf()
     {
         // set up the basic form
@@ -59,7 +64,6 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         // load it with a bad token
         $data = ['foo' => 'bar', '__csrf_token' => 'badvalue'];
-        $this->setExpectedException('Aura\Input\Exception\CsrfViolation');
         $form->fill($data);
     }
 


### PR DESCRIPTION
If you are looking at this PR, you can use w=1 in the url to get rid of whitespace issue .

There are a few things that I dislike, which need to create separate issues. 

1. Collection and failures . 
   a. How to handle the errors on collection.
   b. Retrieving fields from collection

```
// collection-level input
$actual = $this->form->phone_numbers[1]->get('number');
```

2. Phstan reports errors for fill not present in AbstractInput. As we cannot typehint to array in one and mixed in other AbstractInput currently don't have fill method.