### PR TITLE
Pass options from factories to factory methods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -430,6 +430,24 @@ class ContactForm extends Form
 }
 ```
 
+Passing options to the form also works with a FormFactory instance. The first parameter provided to the closure will be whatever is passed as options (the 2nd parameter of `FormFactory::newInstance`).
+
+``` php
+use Aura\Input\Builder;
+use Aura\Input\Filter;
+use Aura\Input\FormFactory;
+use Vendor\Package\ContactForm;
+use Vendor\Package\Options;
+
+$factory = new FormFactory([
+    'contact' => function ($options = null) {
+        return new ContactForm(new Builder(), new Filter(), $options);
+    },
+]);
+
+$form = $factory->newInstance('contact', new Options());
+```  
+
 
 ### Creating Reusable Fieldsets
 
@@ -473,6 +491,30 @@ Now in our `ContactForm` `init()` method we can use `$this->setFieldset('address
 
 ```
 $form = new ContactForm($builder, new Filter);
+```
+
+### Passing Options to Fieldsets
+
+You may need to reuse a fieldset class several times within the same form, and need a way to configure its fields. The builder factory methods can now accept an optional 1st argument to pass options.
+
+``` php
+$builder = new Builder([
+    'my-fieldset' => function ($options = null) {
+        return new MyFieldset(
+            new Builder,
+            new Filter,
+            $options
+        );
+    },
+    // other fieldset if any
+]);
+```
+
+Once registered, the fieldset may be created from within the form:
+
+``` php
+$form = new Form($builder, new Filter());
+$form->setFieldset('foo', 'my-fieldset', ['options here']);
 ```
 
 ### Using Fieldset Collections

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -89,17 +89,19 @@ class Builder implements BuilderInterface
      * @param string $name The fieldset name.
      * 
      * @param string $type The fieldset type.
+     *
+     * @param mixed $options Optional: configuration options for the fieldset.
      * 
      * @return Fieldset
      * 
      */
-    public function newFieldset($name, $type = null)
+    public function newFieldset($name, $type = null, $options = null)
     {
         if (! $type) {
             $type = $name;
         }
         $factory = $this->fieldset_map[$type];
-        $fieldset = $factory();
+        $fieldset = $factory($options);
         $fieldset->setName($name);
         return $fieldset;
     }

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -32,19 +32,21 @@ interface BuilderInterface
      * 
      */
     public function newField($name, $type);
-    
+
     /**
-     * 
+     *
      * Creates a new Fieldset object.
      *
      * @param string $name The fieldset name.
-     *  
+     *
      * @param string $type The fieldset type.
      *
+     * @param mixed $options Optional: configuration options for the fieldset.
+     *
      * @return Fieldset
-     * 
+     *
      */
-    public function newFieldset($name, $type);
+    public function newFieldset($name, $type, $options = null);
     /**
      * 
      * Creates a new Collection object.

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -301,12 +301,14 @@ class Fieldset extends AbstractInput
      *
      * @param string $type A Fieldset of this type; defaults to $name.
      *
+     * @param mixed $options Optional: configuration options for the fieldset.
+     *
      * @return Fieldset
      *
      */
-    public function setFieldset($name, $type = null)
+    public function setFieldset($name, $type = null, $options = null)
     {
-        $this->inputs[$name] = $this->builder->newFieldset($name, $type);
+        $this->inputs[$name] = $this->builder->newFieldset($name, $type, $options);
         return $this->inputs[$name];
     }
 

--- a/src/FormFactory.php
+++ b/src/FormFactory.php
@@ -43,24 +43,25 @@ class FormFactory
     }
 
     /**
-     * 
+     *
      * Returns a new instance of a named form.
-     * 
+     *
      * @param string $name The name of the form to create.
-     * 
+     *
+     * @param mixed $options
+     *
      * @return Form
-     * 
+     *
      * @throws Exception\NoSuchForm When the named form does not exist.
-     * 
      */
-    public function newInstance($name)
+    public function newInstance($name, $options = null)
     {
         if (! isset($this->map[$name])) {
             throw new Exception\NoSuchForm($name);
         }
         
         $factory = $this->map[$name];
-        $form = $factory();
+        $form = $factory($options);
         return $form;
     }
 }

--- a/tests/ConfigurableFieldset.php
+++ b/tests/ConfigurableFieldset.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © 2018 by Wood Street, Inc. All Rights reserved.
+ */
+
+namespace Aura\Input;
+
+class ConfigurableFieldset extends Fieldset
+{
+    public function init()
+    {
+        // call parent for coverage
+        parent::init();
+
+        // pass configuration options to a child field
+        $this->setField('foo', 'select')->setOptions((array) $this->options);
+    }
+}

--- a/tests/ConfigurableForm.php
+++ b/tests/ConfigurableForm.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © 2018 by Wood Street, Inc. All Rights reserved.
+ */
+
+namespace Aura\Input;
+
+
+class ConfigurableForm extends Form
+{
+
+    public function init()
+    {
+        parent::init(); // for code coverage
+
+        $this->setField('foo')->setOptions((array) $this->options);
+    }
+
+}

--- a/tests/FieldsetTest.php
+++ b/tests/FieldsetTest.php
@@ -187,6 +187,28 @@ class FieldsetTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('mock[foo]', $field['name']);
     }
 
+    public function testSetFieldsetOptions()
+    {
+        $map['configurable'] = function ($options = null) {
+            return new ConfigurableFieldset(
+                new Builder(),
+                new Filter(),
+                $options
+            );
+        };
+
+        $fieldset = new Fieldset(
+            new Builder($map),
+            new Filter()
+        );
+
+        $inner = $fieldset->setFieldset('test', 'configurable', ['one', 'two', 'three']);
+        $this->assertInstanceOf(ConfigurableFieldset::class, $inner);
+
+        $field = $inner->get('foo');
+        $this->assertSame(['one', 'two', 'three'], $field['options']);
+    }
+
     public function testSetCollection()
     {
         // a map so the outer fieldset can create the inner collection

--- a/tests/FormFactoryTest.php
+++ b/tests/FormFactoryTest.php
@@ -20,4 +20,24 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Aura\Input\Exception\NoSuchForm');
         $form_factory->newInstance('badname');
     }
+
+    public function testFormOptions() {
+        $map['form'] = function ($options = null) {
+            return new ConfigurableForm(
+                new Builder(),
+                new Filter(),
+                $options
+            );
+        };
+
+        $factory = new FormFactory($map);
+
+        $form = $factory->newInstance('form', ['foo', 'bar', 'baz']);
+        $this->assertInstanceOf(ConfigurableForm::class, $form);
+
+        $field = $form->get('foo');
+        $expected = ['foo', 'bar', 'baz'];
+        $this->assertSame($expected, $field['options']);
+    }
+
 }


### PR DESCRIPTION
Fixes #67.

The factory objects, and factory methods on the Fieldset class, for forms and fieldsets lacked a way to pass options to the respective class' constructor. This pull request corrects the problem by passing an optional parameter to the factory methods.

I made certain to add tests for both new cases, and updated the documentation. I also spent part of today revising the project that needed this feature to work with my branch: so far it has been rock-solid in an actual project (one still under development).


I'm not familiar with what's customary for this, but my boss directly approved me making this effort on company time. Big thanks to my employer for that!