### PR TITLE
Support PHP 8.2-8.5 (bug/compat fix)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,6 +20,10 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
           - '8.5'
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -41,7 +41,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -54,6 +54,6 @@ jobs:
         run: php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+Aura.Input is a PHP library for **describing and filtering HTML form inputs**. It deliberately does NOT render forms — it produces "hints" (type/attribs/options/value arrays) that a view layer (e.g. Aura.Html) consumes. Supports nested fieldsets, fieldset collections, a pluggable filter system via `aura/filter-interface`, and a CSRF protection interface.
+
+Development happens on the `4.x` branch (the `main` branch in this repo's terminology).
+
+## Commands
+
+Install dependencies and run the test suite:
+
+```bash
+composer install
+./vendor/bin/phpunit
+```
+
+Run a single test class or method:
+
+```bash
+./vendor/bin/phpunit tests/FormTest.php
+./vendor/bin/phpunit --filter testFill tests/FormTest.php
+```
+
+Run with coverage (matches the CI invocation in [.github/workflows](.github/workflows)):
+
+```bash
+php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
+```
+
+Run without coverage (faster during iteration):
+
+```bash
+./vendor/bin/phpunit --no-coverage
+```
+
+There are no Composer scripts (`composer test`, `composer cs-fix`, etc.) defined in [composer.json](composer.json) — invoke PHPUnit directly. CI exercises PHP 7.2–8.5 per [.github/workflows/continuous-integration.yml](.github/workflows/continuous-integration.yml).
+
+## Architecture
+
+The class hierarchy is the key thing to internalize before editing:
+
+```
+AbstractInput  (name, name_prefix, getFullName, getValue)
+ ├── Field       (single input, type/attribs/options/value hints)
+ ├── Collection  (repeated fieldsets of the same type)
+ └── Fieldset    (group of inputs; iterable; holds Builder + Filter)
+      └── Form   (top-level Fieldset; adds AntiCsrf + fill() guard)
+```
+
+- [src/AbstractInput.php](src/AbstractInput.php) carries the name/prefix machinery so nested inputs render as `parent[child]`. `getFullName()` is what propagates the prefix to children via `Fieldset::getInput()`.
+- [src/Fieldset.php](src/Fieldset.php) is the workhorse. It holds the `$inputs` array, the injected `BuilderInterface` and `FilterInterface`, and exposes `setField()` / `setFieldset()` / `setCollection()` which all delegate to the builder. `filter()` recurses into nested `Fieldset` and `Collection` children, aggregating failures via `FailureCollectionInterface::addMessagesForField()`. The `init()` hook is the override point for self-initializing subclasses (see [tests/Example/ContactForm.php](tests/Example/ContactForm.php)).
+- [src/Form.php](src/Form.php) extends `Fieldset` only to add `setAntiCsrf()` and a `fill()` override that throws `Exception\CsrfViolation` when the CSRF check fails.
+- [src/Builder.php](src/Builder.php) is the factory for Fields/Fieldsets/Collections. Fieldset types are registered through a `fieldset_map` of `type => callable($options)`. `newFieldset()` and `newCollection()` look up the callable by type (defaulting `type` to `name`). This is how reusable fieldsets like `AddressFieldset` get wired in — see the "Creating Reusable Fieldsets" section of [docs/index.md](docs/index.md).
+- [src/FormFactory.php](src/FormFactory.php) is the same map pattern applied at the Form level: `newInstance($name, $options)` instantiates a registered form factory and forwards options.
+- [src/Filter.php](src/Filter.php) is the bundled `FilterInterface` implementation: closure-based rules keyed by field, applied in `apply(&$values)` where `$values` is the Fieldset itself (closures receive `$value` and `$fields`, where `$fields` is the Fieldset and `$value` is `$fields->$field` via `__get` → `Field::read()`). Failures use the bundled [src/Filter/FailureCollection.php](src/Filter/FailureCollection.php), which stores plain string messages per field (via `addMessagesForField`) and also satisfies `FailureCollectionInterface::add/set` by returning [src/Filter/Failure.php](src/Filter/Failure.php) value objects.
+- [src/AntiCsrfInterface.php](src/AntiCsrfInterface.php) is an interface only — the library intentionally does not ship a CSRF implementation because it depends on user/session infrastructure outside its scope.
+
+### External contract
+
+The package depends on `aura/filter-interface` (`4.x-dev`) for `FilterInterface` and `FailureCollectionInterface`. Filter swap-outs from other libraries must conform to that interface.
+
+## Layout
+
+- `src/` — PSR-4 `Aura\Input\` namespace.
+- `tests/` — PSR-4 `Aura\Input\` namespace (autoload-dev), bootstrapped by [phpunit.php](phpunit.php). [tests/Example/](tests/Example/) contains the canonical fieldset + form + filter usage example covered by `ExampleTest`.
+- `docs/index.md` — the user-facing documentation; treat as the primary spec for public API behavior.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package is installable and PSR-4 autoloadable via Composer as
 
 ## Dependencies
 
-This package requires PHP 7.2 or later; it has been tested on PHP 7.2 - 8.1. We recommend using the latest available version of PHP as a matter of
+This package requires PHP 7.2 or later; it has been tested on PHP 7.2 - 8.5. We recommend using the latest available version of PHP as a matter of
 principle.
 
 Aura library packages may sometimes depend on external interfaces, but never on

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -23,6 +23,15 @@ class CollectionIterator implements Iterator
 {
     /**
      *
+     * The collection over which we are iterating.
+     *
+     * @var Collection
+     *
+     */
+    protected $collection;
+
+    /**
+     *
      * The fieldsets over which we are iterating.
      *
      * @var array

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -53,7 +53,7 @@ class Filter implements FilterInterface
     /**
      * Initialize filters
      */
-    public function __construct(FailureCollectionInterface $failures = null)
+    public function __construct(?FailureCollectionInterface $failures = null)
     {
         if ($failures === null) {
             $failures = new FailureCollection();
@@ -118,7 +118,7 @@ class Filter implements FilterInterface
      * @return bool True if all rules passed; false if one or more failed.
      *
      */
-    public function apply(&$values)
+    public function apply(&$values): bool
     {
         $this->failures = clone $this->proto_failures;
 
@@ -148,7 +148,7 @@ class Filter implements FilterInterface
      * @return FailureCollection
      *
      */
-    public function getFailures()
+    public function getFailures(): FailureCollectionInterface
     {
         return $this->failures;
     }

--- a/src/Filter/Failure.php
+++ b/src/Filter/Failure.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT-license.php MIT
+ *
+ */
+namespace Aura\Input\Filter;
+
+use Aura\Filter_Interface\FailureInterface;
+
+class Failure implements FailureInterface
+{
+    /**
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @var array
+     */
+    protected $args;
+
+    public function __construct(string $field, string $message, array $args = [])
+    {
+        $this->field = $field;
+        $this->message = $message;
+        $this->args = $args;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'field' => $this->field,
+            'message' => $this->message,
+            'args' => $this->args,
+        ];
+    }
+}

--- a/src/Filter/FailureCollection.php
+++ b/src/Filter/FailureCollection.php
@@ -9,8 +9,9 @@
 namespace Aura\Input\Filter;
 
 use Aura\Filter_Interface\FailureCollectionInterface;
+use Aura\Filter_Interface\FailureInterface;
 
-class FailureCollection  implements FailureCollectionInterface
+class FailureCollection implements FailureCollectionInterface
 {
     /**
      *
@@ -25,10 +26,8 @@ class FailureCollection  implements FailureCollectionInterface
      *
      * Is the failure collection empty?
      *
-     * @return bool
-     *
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return count($this->messages) === 0;
     }
@@ -40,8 +39,6 @@ class FailureCollection  implements FailureCollectionInterface
      * @param string $field The field that failed.
      *
      * @param string|array $messages The failure messages.
-     *
-     * @return null
      *
      */
     public function addMessagesForField($field, $messages)
@@ -58,13 +55,33 @@ class FailureCollection  implements FailureCollectionInterface
 
     /**
      *
-     * Returns all failure messages for all fields.
-     *
-     * @return array
+     * Adds a single failure message for a field.
      *
      */
-    public function getMessages()
-    {        
+    public function add(string $field, string $message, array $args = []): FailureInterface
+    {
+        $this->addMessagesForField($field, $message);
+        return new Failure($field, $message, $args);
+    }
+
+    /**
+     *
+     * Sets a single failure message for a field, replacing any previous ones.
+     *
+     */
+    public function set(string $field, string $message, array $args = []): FailureInterface
+    {
+        $this->messages[$field] = [];
+        return $this->add($field, $message, $args);
+    }
+
+    /**
+     *
+     * Returns all failure messages for all fields.
+     *
+     */
+    public function getMessages(): array
+    {
         return $this->messages;
     }
 
@@ -72,15 +89,11 @@ class FailureCollection  implements FailureCollectionInterface
      *
      * Returns all failure messages for one field.
      *
-     * @param string $field The field name.
-     *
-     * @return array
-     *
      */
-    public function getMessagesForField($field)
+    public function getMessagesForField(string $field): array
     {
         if (! isset($this->messages[$field])) {
-            return array();
+            return [];
         }
 
         return $this->messages[$field];

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -103,6 +103,30 @@ class FilterTest extends TestCase
         $this->assertTrue($this->filter->getFailures()->isEmpty());
     }
 
+    public function testFailureCollectionAddAndSet()
+    {
+        $failures = new \Aura\Input\Filter\FailureCollection;
+        $this->assertTrue($failures->isEmpty());
+
+        $first = $failures->add('foo', 'first message', ['arg' => 1]);
+        $this->assertInstanceOf(\Aura\Filter_Interface\FailureInterface::class, $first);
+        $this->assertSame('foo', $first->getField());
+        $this->assertSame('first message', $first->getMessage());
+        $this->assertSame(['arg' => 1], $first->getArgs());
+
+        $failures->add('foo', 'second message');
+        $this->assertSame(['first message', 'second message'], $failures->getMessagesForField('foo'));
+
+        $replaced = $failures->set('foo', 'only message');
+        $this->assertInstanceOf(\Aura\Filter_Interface\FailureInterface::class, $replaced);
+        $this->assertSame(['only message'], $failures->getMessagesForField('foo'));
+
+        $this->assertSame(
+            ['field' => 'foo', 'message' => 'only message', 'args' => []],
+            $replaced->jsonSerialize()
+        );
+    }
+
     public function testMultipleErrorMessages()
     {
         // initial data


### PR DESCRIPTION
Aligns `Filter` and `FailureCollection` with `aura/filter-interface` 4.x strict types — the existing signatures fail with a fatal error on every PHP version. Also extends CI to PHP 8.2-8.5 and resolves PHP 8.4 implicit-nullable / PHP 8.2 dynamic-property deprecations.

This is the bug/compatibility fix raised in #77. Broader `aura/filter` integration and multidimensional array support are out of scope.